### PR TITLE
Updates regexp-match-indices feature to support 'd' flag

### DIFF
--- a/src/parser/Lexer.mjs
+++ b/src/parser/Lexer.mjs
@@ -9,6 +9,7 @@ import {
   KeywordLookup,
   isKeywordRaw,
 } from './tokens.mjs';
+import { surroundingAgent } from '../engine.mjs';
 
 const isUnicodeIDStart = (c) => c && isUnicodeIDStartRegex.test(c);
 const isUnicodeIDContinue = (c) => c && isUnicodeIDContinueRegex.test(c);
@@ -887,7 +888,7 @@ export class Lexer {
       }
       const c = this.source[this.position];
       if (isRegularExpressionFlagPart(c)
-          && 'gimsuy'.includes(c)
+          && (surroundingAgent.feature('regexp-match-indices') ? 'dgimsuy' : 'gimsuy').includes(c)
           && !buffer.includes(c)) {
         this.position += 1;
         buffer += c;


### PR DESCRIPTION
This brings engine262 up-to-date with the changes for `regexp-match-indices` to use a `d` flag to opt in to returning `.indices` when calling `.exec()` (or any other function that calls `RegExpBuiltinExec`.